### PR TITLE
Add editorconfig to force Atom to 2-space indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.md]
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
Hey, not sure if this is useful for anyone else but here's an `.editorconfig` I've added to my local projects to ensure my code editor (Atom) conforms to the project indentation etc.

May be useful for others to have it force the existing coding style where editors support it; http://editorconfig.org/