### PR TITLE
Refine strings

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,14 +1,14 @@
 {
   "appName": {
     "message": "Ext Starter",
-    "description": "The name of the application"
-  },
-  "btnTooltip": {
-    "message": "Ext Starter",
-    "description": "Tooltip for button"
+    "description": "The name of the extension."
   },
   "appDescription": {
     "message": "Boilerplate for building cross browser extensions",
-    "description": "The description of the application"
+    "description": "The description of the extension."
+  },
+  "btnTooltip": {
+    "message": "Ext Starter",
+    "description": "Tooltip for the button."
   }
 }


### PR DESCRIPTION
* Refine the order.
* Add punctuation for descriptions.
* Use "extension" instead of "application" to avoid misinterpreting it as a browser/application.