### PR TITLE
Fix Issue #40

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-run-sequence": "*",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "3.0.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.4",
     "gulp-zip": "^2.0.3",


### PR DESCRIPTION
# Bump gulp-sass from 2.3.2 to 3.0.0 😄  (This Fix Issue #40)

Error when making `npm install`

I solved this by changing in package.json:
`"gulp-sass": "^2.3.2"`
to
`"gulp-sass": "3.0.0",`

https://github.com/codecombat/codecombat/issues/4430#issuecomment-348927771

```
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-sass@3.13.1 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-sass@3.13.1 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\yrrod_000\AppData\Roaming\npm-cache\_logs\2019-10-18T09_03_25_525Z-debug.log